### PR TITLE
feat(#1): Handle collisions

### DIFF
--- a/game/logic/turn-engine.js
+++ b/game/logic/turn-engine.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const Coordinate = require('../tiles/coordinate')
+const moveValidator = require('../validators/moveValidator')
 
 function processMoves (room, entities, entitiesMove) {
   const newEntities = {}
@@ -8,11 +9,13 @@ function processMoves (room, entities, entitiesMove) {
   for (const entityId in entities) {
     const move = entitiesMove[entityId]
     let uniquePosition = true
+    let collisionPosition
     // if the entity is moving this turn
     if (move) {
       // check that the entities desired position isn't already taken
       for (const e in newEntities) {
         if (Coordinate.isSame(move, newEntities[e].position)) {
+          collisionPosition = newEntities[e].position
           uniquePosition = false
           break
         }
@@ -24,15 +27,43 @@ function processMoves (room, entities, entitiesMove) {
         newEntities[entityId].position = entitiesMove[entityId]
       } else {
         // Else find the second closest square to the entity which is free
-        // TODO: fix this
+        const closestCoordinate = findClosestCoordinate(room, entities[entityId].position, collisionPosition, newEntities)
+        
         newEntities[entityId] = entities[entityId]
-        newEntities[entityId].position = new Coordinate(1, 1)
+        newEntities[entityId].position = closestCoordinate
       }
     }
   }
 
   // re-assign the entities list
   entities = newEntities
+}
+
+function findClosestCoordinate (room, currentPosition, desiredPosition) {
+  // Note, its possible none of these squares are available. Possibly might have to go for an interative approach
+  const moveSet = [
+    new Coordinate(0, 1),
+    new Coordinate(0, -1),
+    new Coordinate(1, 0),
+    new Coordinate(-1, 0)
+  ]
+
+  // Mock entity to find valid squares surrounding desired position
+  const entity = { position: desiredPosition, moveSet: moveSet }
+  const validMoveSet = moveValidator.calculateMoveSet(entity, room)
+  console.log(validMoveSet)
+  let bestMove
+  let shortestDist = 10000
+  for (const key in validMoveSet) {
+    const potentialMove = validMoveSet[key]
+    const potentialMoveCoords = new Coordinate(potentialMove.x + desiredPosition.x, potentialMove.y + desiredPosition.y)
+    const dist = Math.sqrt(Math.pow((potentialMoveCoords.x - currentPosition.x), 2) + Math.pow((potentialMoveCoords.y - currentPosition.y), 2))
+    if (dist < shortestDist) {
+      shortestDist = dist
+      bestMove = potentialMoveCoords
+    }
+  }
+  return bestMove
 }
 
 module.exports = processMoves

--- a/game/logic/turn-engine.js
+++ b/game/logic/turn-engine.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const Coordinate = require('../tiles/coordinate')
+
+function processMoves (room, entities, entitiesMove) {
+  const newEntities = {}
+
+  for (const entityId in entities) {
+    const move = entitiesMove[entityId]
+    let uniquePosition = true
+    // if the entity is moving this turn
+    if (move) {
+      // check that the entities desired position isn't already taken
+      for (const e in newEntities) {
+        if (Coordinate.isSame(move, newEntities[e].position)) {
+          uniquePosition = false
+          break
+        }
+      }
+
+      if (uniquePosition) {
+        // If position is unique add them to the list of new entities with new position
+        newEntities[entityId] = entities[entityId]
+        newEntities[entityId].position = entitiesMove[entityId]
+      } else {
+        // Else find the second closest square to the entity which is free
+        // TODO: fix this
+        newEntities[entityId] = entities[entityId]
+        newEntities[entityId].position = new Coordinate(1, 1)
+      }
+    }
+  }
+
+  // re-assign the entities list
+  entities = newEntities
+}
+
+module.exports = processMoves

--- a/game/logic/turn-engine.js
+++ b/game/logic/turn-engine.js
@@ -28,7 +28,7 @@ function processMoves (room, entities, entitiesMove) {
       } else {
         // Else find the second closest square to the entity which is free
         const closestCoordinate = findClosestCoordinate(room, entities[entityId].position, collisionPosition, newEntities)
-        
+
         newEntities[entityId] = entities[entityId]
         newEntities[entityId].position = closestCoordinate
       }
@@ -51,7 +51,6 @@ function findClosestCoordinate (room, currentPosition, desiredPosition) {
   // Mock entity to find valid squares surrounding desired position
   const entity = { position: desiredPosition, moveSet: moveSet }
   const validMoveSet = moveValidator.calculateMoveSet(entity, room)
-  console.log(validMoveSet)
   let bestMove
   let shortestDist = 10000
   for (const key in validMoveSet) {

--- a/game/tiles/coordinate.js
+++ b/game/tiles/coordinate.js
@@ -5,6 +5,16 @@ class Coordinate {
     this.x = x
     this.y = y
   }
+
+  static isSame (coordinate1, coordinate2) {
+    const sameX = (coordinate1.x === coordinate2.x)
+    const sameY = (coordinate1.y === coordinate2.y)
+    if (sameX && sameY) {
+      return true
+    } else {
+      return false
+    }
+  }
 }
 
 module.exports = Coordinate

--- a/server/server.js
+++ b/server/server.js
@@ -5,6 +5,7 @@ const app = express()
 const database = require('./database')
 const moveValidator = require('../game/validators/moveValidator')
 const moveAlgorith = require('../game/ai/move-algorithms')
+const turnEngine = require('../game/logic/turn-engine')
 const Coordinate = require('../game/tiles/coordinate')
 const PORT = 6930
 
@@ -41,34 +42,36 @@ app.get('/instance', AuthController.verifyToken, (req, res) => {
 app.post('/instance', AuthController.verifyToken, (req, res) => {
   database.getInstance(req.username).then((instance) => {
     // Find player id
+    let playerId = null
     for (const key in instance.entities) {
       if (instance.entities[key].name === req.username) {
-        this.playerId = instance.entities[key].id
+        playerId = instance.entities[key].id
       }
     }
     const playerRequestedCoordinates = req.body.move
-    const player = instance.entities[this.playerId]
+    const player = instance.entities[playerId]
 
     const move = new Coordinate(playerRequestedCoordinates.x - player.position.x, playerRequestedCoordinates.y - player.position.y)
     const moveValid = moveValidator.isMoveValid(player, instance.room, move)
 
     if (moveValid) {
+      const entityDesiredMoves = {}
+
       for (const key in instance.entities) {
         const entity = instance.entities[key]
 
         if (entity.type !== 'Player') {
-          const newCoords = moveAlgorith[entity.moveAlgorith](entity.id, instance.entities, instance.room)
-          entity.position = new Coordinate(newCoords.x, newCoords.y)
+          entityDesiredMoves[entity.id] = moveAlgorith[entity.moveAlgorith](entity.id, instance.entities, instance.room)
         }
       }
+      entityDesiredMoves[playerId] = new Coordinate(playerRequestedCoordinates.x, playerRequestedCoordinates.y)
+      turnEngine(instance.room, instance.entities, entityDesiredMoves)
 
-      player.position.x = playerRequestedCoordinates.x
-      player.position.y = playerRequestedCoordinates.y
       database.updateInstance(req.username, instance)
 
       // Calculate players valid move set
       const validMoveSet = moveValidator.calculateMoveSet(player, instance.room)
-      instance.entities[this.playerId].moveSet = validMoveSet
+      instance.entities[playerId].moveSet = validMoveSet
 
       res.send(instance)
     } else {

--- a/test/test.js
+++ b/test/test.js
@@ -1,9 +1,15 @@
-import test from 'ava'
-import moveValidator from '../game/validators/moveValidator'
-import moveAlgorith from '../game/ai/move-algorithms'
-import Player from '../game/entitys/player'
-import Zombie from '../game/entitys/zombie'
-import Coordinate from '../game/tiles/coordinate'
+const test = require('ava')
+const moveValidator = require('../game/validators/moveValidator')
+const moveAlgorith = require('../game/ai/move-algorithms')
+const Player = require('../game/entitys/player')
+const Zombie = require('../game/entitys/zombie')
+const Coordinate = require('../game/tiles/coordinate')
+const turnEngine = require('../game/logic/turn-engine')
+
+test('fileName-functionName-exampleTest', t => {
+  const a = 1
+  t.is(a, 1)
+})
 
 // Testing moveValidator
 test('moveValidator-isMoveValid-allowedMove', t => {
@@ -91,4 +97,40 @@ test('moveAlgorith-zombieMove-NavigateToPlayer', t => {
 
   t.is(zombie.position.x, 6)
   t.is(zombie.position.y, 6)
+})
+
+// Testing turn-engine
+test('turnEngine-processMoves-noCollision', t => {
+  const room = { width: 10, height: 10 }
+  const entity1 = { position: new Coordinate(3, 3) }
+  const entity2 = { position: new Coordinate(3, 5) }
+  const entitiesMove = { '1': new Coordinate(4, 3), '2': new Coordinate(4, 5) }
+  const entities = { '1': entity1, '2': entity2 }
+  turnEngine(room, entities, entitiesMove)
+  t.deepEqual(entities['1'].position, new Coordinate(4, 3))
+  t.deepEqual(entities['2'].position, new Coordinate(4, 5))
+})
+
+test('turnEngine-processMoves-withCollision', t => {
+  const room = { width: 10, height: 10 }
+  const entity1 = { position: new Coordinate(3, 3) }
+  const entity2 = { position: new Coordinate(3, 5) }
+  const entitiesMove = { '1': new Coordinate(3, 4), '2': new Coordinate(3, 4) }
+  const entities = { '1': entity1, '2': entity2 }
+  turnEngine(room, entities, entitiesMove)
+  t.deepEqual(entities['1'].position, new Coordinate(3, 4))
+  t.deepEqual(entities['2'].position, new Coordinate(3, 5))
+})
+
+// Testing Coordinate
+test('coordinate-isSame-same', t => {
+  const a = new Coordinate(0, 0)
+  const b = new Coordinate(0, 0)
+  t.is(Coordinate.isSame(a, b), true)
+})
+
+test('coordinate-isSame-different', t => {
+  const a = new Coordinate(0, 1)
+  const b = new Coordinate(0, 0)
+  t.is(Coordinate.isSame(a, b), false)
 })


### PR DESCRIPTION
This pull request adds a system to handle collisions between entities during a turn. 

The `turn-engine.js` processes all the desired moves of entities that turn. It goes through the array of entities moving that turn and moves them one by one. Before each entity is moved the system checks if its desired move location is already taken. If the location is taken then the entity is moved to the next closest location instead. 