### PR TITLE
feat(#5): Added ability for players to attack

### DIFF
--- a/client/game-manager.js
+++ b/client/game-manager.js
@@ -42,10 +42,17 @@ class GameManager {
         this.uiManager.reset()
       }
       if (change.newTurn) {
-        for (const key in change.newTurn) {
-          const entity = change.newTurn[key]
+        for (const key in change.newTurn.moveSet) {
+          const entity = change.newTurn.moveSet[key]
           this.view.renderEntityTurn(entity)
         }
+        const attempts = change.newTurn.attackSet
+        attempts.forEach((attempt) => {
+          console.log(`${attempt.attacker.name} attacked (${attempt.attack.x}, ${attempt.attack.y})`)
+          attempt.targets.forEach((attack) => {
+            console.log(`Attack hit ${attack.target.name} for ${attack.damage}. ${attack.target.name} now has ${attack.target.health}/${attack.target.maxHealth} left!`)
+          })
+        })
       }
     })
 

--- a/client/game-manager.js
+++ b/client/game-manager.js
@@ -30,18 +30,15 @@ class GameManager {
       if (change.operation === 'add') {
         if (checkIfEntityPlayer(window.localStorage.getItem('username'), change.value)) {
           this.playerId = change.value.id
-          console.log(`Found player: ${change.value.name} with id = ${change.value.id}`)
         }
         this.view.renderEntity(change.value)
       }
     })
 
     room.onMessage.add((change) => {
-      console.log(change)
-      if (change.turnSet) {
-        this.uiState.moveSet = change.turnSet.validMoves
-        this.uiState.attackSet = change.turnSet.validAttacks
-        this.uiState.position = change.turnSet.position
+      if (change.turnInfo) {
+        this.uiState.player = change.turnInfo.player
+        this.uiState.map = change.turnInfo.map
         this.uiManager.reset()
       }
       if (change.newTurn) {

--- a/client/ui/attackButton.js
+++ b/client/ui/attackButton.js
@@ -2,6 +2,7 @@
 
 import Button from './button'
 import AttackSquare from './attackSquare'
+import attackValidator from '../../game/validators/attackValidator'
 
 class AttackButton extends Button {
   constructor (stage, uiManager, playerState, turnSet) {
@@ -18,13 +19,17 @@ class AttackButton extends Button {
 
   setActive () {
     this.setUnActive()
+    const attackSet = attackValidator.calculateValidAttackSet({
+      position: this.playerState.nextPos,
+      weapon: this.playerState.player.weapon },
+    this.playerState.map)
     super.setActive(() => {
-      for (const key in this.playerState.attackSet) {
-        const attack = this.playerState.attackSet[key]
+      for (const key in attackSet) {
+        const attack = attackSet[key]
         this.attackSquares.push(new AttackSquare(
           this.stage,
           attack,
-          this.playerState.position,
+          this.playerState.nextPos,
           this.turnSet,
           () => {
             this.uiManager.setNextActive()

--- a/client/ui/moveButton.js
+++ b/client/ui/moveButton.js
@@ -2,6 +2,7 @@
 
 import Button from './button'
 import MoveSquare from './moveSquare'
+import moveValidator from '../../game/validators/moveValidator'
 
 class MoveButton extends Button {
   constructor (stage, uiManager, playerState, turnSet) {
@@ -17,21 +18,24 @@ class MoveButton extends Button {
 
   setActive () {
     this.setUnActive()
-    super.setActive(() => {
-      for (const key in this.playerState.moveSet) {
-        const move = this.playerState.moveSet[key]
-        this.moveSquares.push(new MoveSquare(
-          this.stage,
-          move,
-          this.playerState.position,
-          this.turnSet,
-          () => {
-            this.uiManager.setNextActive()
-          }
-        )
-        )
-      }
-    })
+    if (this.playerState.player && this.playerState.map) {
+      const moveSet = moveValidator.calculateMoveSet(this.playerState.player, this.playerState.map)
+      super.setActive(() => {
+        for (const key in moveSet) {
+          const move = moveSet[key]
+          this.moveSquares.push(new MoveSquare(
+            this.stage,
+            move,
+            this.playerState,
+            this.turnSet,
+            () => {
+              this.uiManager.setNextActive()
+            }
+          )
+          )
+        }
+      })
+    }
   }
 
   setUnActive () {

--- a/client/ui/moveSquare.js
+++ b/client/ui/moveSquare.js
@@ -1,13 +1,15 @@
 'use strict'
 
 import Square from './square'
+import Coordinate from '../../game/tiles/coordinate'
 
 class MoveSquare extends Square {
-  constructor (stage, position, playerPosition, turnSet, close) {
-    super(stage, { color: 0x00FF00 }, position, playerPosition)
+  constructor (stage, position, playerState, turnSet, close) {
+    super(stage, { color: 0x00FF00 }, position, playerState.player.position)
     this.turnSet = turnSet
     this.onClick(() => {
-      turnSet.move = this.position
+      turnSet.move = position
+      playerState.nextPos = Coordinate.addCoodinates(position, playerState.player.position)
       close()
     })
   }

--- a/client/ui/uiManager.js
+++ b/client/ui/uiManager.js
@@ -68,6 +68,14 @@ class uiManager {
     this.update()
   }
 
+  hide () {
+    for (const key in this.buttons) {
+      const button = this.buttons[key]
+      button.status = 'hide'
+    }
+    this.update()
+  }
+
   reset () {
     for (const key in this.buttons) {
       const button = this.buttons[key]

--- a/game/entitys/player.js
+++ b/game/entitys/player.js
@@ -6,7 +6,7 @@ class Player extends Entity {
   constructor (name, position) {
     super(name, 100, position)
     this.type = 'Player'
-    this.weapon = 'PreserverMachete'
+    this.weapon = 'PreserverRifle'
     this.moveSet = [
       new Coordinate(2, 0),
       new Coordinate(1, -1),

--- a/game/entitys/player.js
+++ b/game/entitys/player.js
@@ -1,5 +1,6 @@
 const Entity = require('./entity')
 const Coordinate = require('../tiles/coordinate')
+const getWeaponDamage = require('../weapons/weapon')
 
 class Player extends Entity {
   constructor (name, position) {
@@ -20,6 +21,10 @@ class Player extends Entity {
       new Coordinate(-1, 1),
       new Coordinate(-2, 0)
     ]
+  }
+
+  getWeaponDamage () {
+    return getWeaponDamage(this.weapon)
   }
 }
 

--- a/game/logic/attack-engine.js
+++ b/game/logic/attack-engine.js
@@ -10,6 +10,7 @@ function processAttacks (room, entities, entityAttacks) {
   return entityAttacks.map(attempt => {
     return {
       // Calculate if the attack hits anything
+      turn: 'action',
       targets: calculateAttack(attempt, entities),
       attack: attempt.attack,
       attacker: attempt.attacker

--- a/game/logic/attack-engine.js
+++ b/game/logic/attack-engine.js
@@ -1,0 +1,42 @@
+'use strict'
+
+const Coordinate = require('../tiles/coordinate')
+
+/**
+ * This function proccesses all of the attacks for a given room. It should be called after entities have already been moved.
+ * It will deal the damage to entities been hit, and return an object which represents the results of all the attacks taken that turn.
+ */
+function processAttacks (room, entities, entityAttacks) {
+  return entityAttacks.map(attempt => {
+    return {
+      // Calculate if the attack hits anything
+      targets: calculateAttack(attempt, entities),
+      attack: attempt.attack,
+      attacker: attempt.attacker
+    }
+  })
+}
+
+function calculateAttack (attempt, entities) {
+  const targets = []
+  for (const key in entities) {
+    const entity = entities[key]
+    const relativeLocation = Coordinate.addCoodinates(attempt.attacker.position, attempt.attack)
+    attempt.attack.attackPattern.forEach((square) => {
+      const targetLocation = Coordinate.addCoodinates(square, relativeLocation)
+      if (Coordinate.isSame(entity.position, targetLocation)) {
+        const damage = attempt.attacker.getWeaponDamage()
+        entity.health -= damage
+        console.log(`Attack hit ${entity.name} for ${damage}. ${entity.name} now has ${entity.health}/${entity.maxHealth} left!`)
+        targets.push({
+          target: entity,
+          damage: damage,
+          location: targetLocation
+        })
+      }
+    })
+  }
+  return targets
+}
+
+module.exports = processAttacks

--- a/game/tiles/coordinate.js
+++ b/game/tiles/coordinate.js
@@ -16,6 +16,10 @@ class Coordinate {
     }
   }
 
+  static addCoodinates (coordinate1, coordinate2) {
+    return new Coordinate(coordinate1.x + coordinate2.x, coordinate1.y + coordinate2.y)
+  }
+
   apply (coordinate) {
     return new Coordinate(this.x + coordinate.x, this.y + coordinate.y)
   }

--- a/game/weapons/weapon.js
+++ b/game/weapons/weapon.js
@@ -1,0 +1,10 @@
+const yaml = require('js-yaml')
+const fs = require('fs')
+
+const weapons = yaml.load(fs.readFileSync('./game/weapons/weapons.yml'))
+
+function getWeaponDamage (name) {
+  return weapons.Weapons[name].damage
+}
+
+module.exports = getWeaponDamage

--- a/game/weapons/weapons.yml
+++ b/game/weapons/weapons.yml
@@ -39,7 +39,22 @@ Weapons:
       - x: -3
         y: 0
         attackPattern: *star
-    damage: 25
+      - x: 2
+        y: -1
+        attackPattern: *star
+      - x: 1
+        y: -2
+        attackPattern: *star
+      - x: 0
+        y: -3
+        attackPattern: *star
+      - x: -1
+        y: -2
+        attackPattern: *star
+      - x: -2
+        y: -1
+        attackPattern: *star
+    damage: 10
 
   PreserverMachete:
     name: Preserver Machete

--- a/server/rooms/battle.js
+++ b/server/rooms/battle.js
@@ -27,7 +27,6 @@ class BattleRoom extends Room {
     this.sessions = {}
     this.timeOut = Math.floor(Date.now() / 1000) + turnTimeout
     setTimeout(() => this.executeTurn(), turnTimeout * 1000)
-    console.log(this.timeOut)
     this.setState({
       entities: {},
       map: rooms['startRoom']
@@ -56,11 +55,10 @@ class BattleRoom extends Room {
     const entityId = this.sessions[client.auth.username].entityId
     delete this.sessions[client.auth.username]
     delete this.state.entities[entityId]
-    console.log(client.id + ' has left')
+    console.log(client.auth.username + ' has left')
   }
 
   onMessage (client, data) {
-    console.log(data)
     if (data.turnSet) {
       this.sessions[client.auth.username].turnSet = data.turnSet
       this.sessions[client.auth.username].ready = true
@@ -78,7 +76,6 @@ class BattleRoom extends Room {
     clearTimeout(this.timerFunc)
     const currTime = Math.floor(Date.now() / 1000)
     this.timeOut = currTime + turnTimeout
-    console.log(this.sessions)
     // Move all entities
     const turnSet = {}
     const entityDesiredMoves = {}
@@ -126,6 +123,7 @@ class BattleRoom extends Room {
       this.sessions[key].turnSet = null
     }
     this.timerFunc = setTimeout(() => this.executeTurn(), (turnTimeout * 1000))
+    console.log('Turn Executed')
   }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -136,6 +136,20 @@ test('coordinate-isSame-different', t => {
   t.is(Coordinate.isSame(a, b), false)
 })
 
+test('coordinate-addCoodinates-simple', t => {
+  const a = new Coordinate(0, 1)
+  const b = new Coordinate(1, 2)
+  const c = Coordinate.addCoodinates(a, b)
+  t.deepEqual(c, new Coordinate(1, 3))
+})
+
+test('coordinate-addCoodinates-negative', t => {
+  const a = new Coordinate(0, 1)
+  const b = new Coordinate(-1, -2)
+  const c = Coordinate.addCoodinates(a, b)
+  t.deepEqual(c, new Coordinate(-1, -1))
+})
+
 test('attackValidator-calculateValidAttackSet-allInMap', t => {
   const player = new Player('Player', new Coordinate(5, 0))
   const room = { width: 10, height: 10 }


### PR DESCRIPTION
Implemented attacking for players. This includes 
1. client calculating and rendering possible attack locations in the UI
2. client sending the attack information to the server
3. server processing attacks, dealing damage to entities hit
4. server sending back attack outcome
5. client rendering attack with simple animation (lol)

Also while working on this I refactored where players valid moves are calculated. Client now preforms these calculations as opposed to server. https://github.com/Sokojoe/cyberpunk/commit/3360a388109598f9fdba941222a7f6bbb7690b19

Also while working on this I completed https://github.com/Sokojoe/cyberpunk/issues/14 , because I wanted attack animations to occur after movement was finished.

Note: Death is still not implemented. Here is a issue for it. https://github.com/Sokojoe/cyberpunk/issues/29
