### PR TITLE
fix(#33): Multiple entities for same user 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ typings/
 
 # next.js build output
 .next
+
+# vs code
+.vscode

--- a/client/components/Pixi.jsx
+++ b/client/components/Pixi.jsx
@@ -12,6 +12,10 @@ class Pixi extends React.Component {
     this.gameCanvas.appendChild(this.app.view)
   }
 
+  componentWillUnmount () {
+    this.gameManager.disconnect()
+  }
+
   render () {
     let component = this
     return (

--- a/server/rooms/battle.js
+++ b/server/rooms/battle.js
@@ -11,9 +11,10 @@ const attackEngine = require('../../game/logic/attack-engine')
 const turnTimeout = 5000
 
 class BattleRoom extends Room {
-  onAuth (options, test) {
+  onAuth (options) {
     return new Promise((resolve, reject) => {
       AuthController.tokenValid(options.authtoken).then((decoded) => {
+        if (this.sessions[decoded.username]) reject(new Error('User already connected.'))
         resolve(decoded)
       }).catch((err) => {
         reject(err)


### PR DESCRIPTION
This PR fixes the bug where when the same user connected multiple times, multiple entities for the same user would be created in `battleroom.js`. Now only the first user is able to connect to the room, the others will fail at `onAuth()`.

One issue is to fail them the promise must be rejected with an error... This is not an error with the server code so ideally the error shouldn't be logged in console however this is a non-blocking issue.  