### PR TITLE
feat(#31): Display entities health as a health bar above entity

### DIFF
--- a/client/pixi-ui/entitySprite.js
+++ b/client/pixi-ui/entitySprite.js
@@ -20,6 +20,61 @@ class Username extends PIXI.Text {
   }
 }
 
+class HealthBar extends PIXI.Container {
+  constructor () {
+    super()
+    this.outerBar = new PIXI.Graphics()
+    // Create black rectangle for behind part of healthbar
+    this.outerBar.beginFill(0x000000)
+    this.outerBar.drawRect(7, 10, 50, 6)
+    this.outerBar.endFill()
+    this.addChild(this.outerBar)
+  }
+
+  renderHealth (health, maxHealth) {
+    this.removeChild(this.innerBar)
+
+    const healthPercent = health / maxHealth
+
+    // Determine healthbar length
+    let healthLength = 48 * healthPercent
+    if (healthLength < 0) {
+      healthLength = 0
+    }
+
+    // Determine healthbar color
+    let color
+    if (healthPercent >= 0.9) {
+      color = 0x33fc07
+    } else if (healthPercent >= 0.8) {
+      color = 0x75fc07
+    } else if (healthPercent >= 0.7) {
+      color = 0x81fc07
+    } else if (healthPercent >= 0.6) {
+      color = 0xaefc07
+    } else if (healthPercent >= 0.5) {
+      color = 0xffd400
+    } else if (healthPercent >= 0.4) {
+      color = 0xfc9a07
+    } else if (healthPercent >= 0.3) {
+      color = 0xfc6407
+    } else if (healthPercent >= 0.2) {
+      color = 0xfc4807
+    } else if (healthPercent >= 0.1) {
+      color = 0xff0000
+    } else {
+      color = 0xbc0000
+    }
+
+    // Create and display healthbar
+    this.innerBar = new PIXI.Graphics()
+    this.innerBar.beginFill(color)
+    this.innerBar.drawRect(8, 11, healthLength, 4)
+    this.innerBar.endFill()
+    this.addChild(this.innerBar)
+  }
+}
+
 class EntitySprite extends PIXI.Container {
   constructor (entity, roomHeight) {
     super()
@@ -38,11 +93,18 @@ class EntitySprite extends PIXI.Container {
     this.name = new Username(entity.name.toUpperCase())
     this.nameContainer = new PIXI.Container()
     this.nameContainer.x = TILE_SIZE / 2
-
     this.nameContainer.addChild(this.name)
+
+    this.healthBar = new HealthBar()
+    this.renderHealth(entity.health, entity.maxHealth)
 
     this.addChild(this.sprite)
     this.addChild(this.nameContainer)
+    this.addChild(this.healthBar)
+  }
+
+  renderHealth (health, maxHealth) {
+    this.healthBar.renderHealth(health, maxHealth)
   }
 }
 

--- a/client/pixi.js
+++ b/client/pixi.js
@@ -55,6 +55,7 @@ class View {
     const sprite = this.entitySprites[action.attacker.id]
     // console.log(`${action.attacker.name} attacked (${action.attack.x}, ${action.attack.y}).`)
     action.targets.forEach((attack) => {
+      this.entitySprites[attack.target.id].renderHealth(attack.target.health, attack.target.maxHealth)
       console.log(`Attack hit ${attack.target.name} for ${attack.damage}. ${attack.target.name} now has ${attack.target.health}/${attack.target.maxHealth} left!`)
     })
 

--- a/game/entitys/player.js
+++ b/game/entitys/player.js
@@ -6,7 +6,7 @@ class Player extends Entity {
   constructor (name, position) {
     super(name, 100, position)
     this.type = 'Player'
-    this.weapon = 'PreserverRifle'
+    this.weapon = 'EqualizerHandgun'
     this.moveSet = [
       new Coordinate(2, 0),
       new Coordinate(1, -1),

--- a/game/weapons/weapons.yml
+++ b/game/weapons/weapons.yml
@@ -13,6 +13,50 @@ AttackPatterns:
       y: 1
     - x: 0
       y: -1
+  t_up: &t_up
+    - x: 0
+      y: 0
+    - x: 0
+      y: 1
+    - x: 0
+      y: 2
+    - x: 1
+      y: 2
+    - x: -1
+      y: 2
+  t_left: &t_left
+    - x: 0
+      y: 0
+    - x: -1
+      y: 0
+    - x: -2
+      y: 0
+    - x: -2
+      y: -1
+    - x: -2
+      y: 1
+  t_right: &t_right
+    - x: 0
+      y: 0
+    - x: 1
+      y: 0
+    - x: 2
+      y: 0
+    - x: 2
+      y: -1
+    - x: 2
+      y: 1
+  t_down: &t_down
+    - x: 0
+      y: 0
+    - x: 0
+      y: -1
+    - x: 0
+      y: -2
+    - x: 1
+      y: -2
+    - x: -1
+      y: -2
 
 Weapons:
   PreserverRifle:
@@ -55,6 +99,82 @@ Weapons:
         y: -1
         attackPattern: *star
     damage: 10
+  EqualizerHandgun:
+    name: Equalizer Handgun
+    damage: 10
+    attackSet:
+      - x: -1
+        y: 2
+        attackPattern: *t_up
+      - x: 0
+        y: 2
+        attackPattern: *t_up
+      - x: 1
+        y: 2
+        attackPattern: *t_up
+      - x: -1
+        y: 3
+        attackPattern: *t_up
+      - x: 0
+        y: 3
+        attackPattern: *t_up
+      - x: 1
+        y: 3
+        attackPattern: *t_up
+      - x: -2
+        y: 1
+        attackPattern: *t_left
+      - x: -2
+        y: 0
+        attackPattern: *t_left
+      - x: -2
+        y: -1
+        attackPattern: *t_left
+      - x: -3
+        y: 1
+        attackPattern: *t_left
+      - x: -3
+        y: 0
+        attackPattern: *t_left
+      - x: -3
+        y: -1
+        attackPattern: *t_left
+      - x: 2
+        y: 1
+        attackPattern: *t_right
+      - x: 2
+        y: 0
+        attackPattern: *t_right
+      - x: 2
+        y: -1
+        attackPattern: *t_right
+      - x: 3
+        y: 1
+        attackPattern: *t_right
+      - x: 3
+        y: 0
+        attackPattern: *t_right
+      - x: 3
+        y: -1
+        attackPattern: *t_right
+      - x: -1
+        y: -2
+        attackPattern: *t_down
+      - x: 0
+        y: -2
+        attackPattern: *t_down
+      - x: 1
+        y: -2
+        attackPattern: *t_down
+      - x: -1
+        y: -3
+        attackPattern: *t_down
+      - x: 0
+        y: -3
+        attackPattern: *t_down
+      - x: 1
+        y: -3
+        attackPattern: *t_down
 
   PreserverMachete:
     name: Preserver Machete


### PR DESCRIPTION
This PR adds health bars above entity's which displays their current health %.

After being dealt damage their health bar should decrease.

The color of the health-bar will reflect the amount of health left. 
Green being high health and red being low health. 